### PR TITLE
Add misc/supplementalData

### DIFF
--- a/icu-filters/optimal.json
+++ b/icu-filters/optimal.json
@@ -89,6 +89,7 @@
                 "numberingSystems",
                 "icuver",
                 "langInfo",
+                "supplementalData",
                 "keyTypeData"
             ]
         },


### PR DESCRIPTION
This fixes `culture.DateTimeFormat.FirstDayOfWeek` to return something other than fallback "Sunday". 
And other DateTime related APIs.