### PR TITLE
Add more flags to turn off features we don't need, add "--tracing" option

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -33,10 +33,6 @@ while [[ $# > 0 ]]; do
       properties="$properties /p:IcuTracing=true"
       ;;
     *)
-      echo "Invalid argument: $1"
-      usage
-      exit 1
-      ;;
   esac
   shift
 done

--- a/build.sh
+++ b/build.sh
@@ -12,5 +12,36 @@ while [[ -h $source ]]; do
   [[ $source != /* ]] && source="$scriptroot/$source"
 done
 
+usage()
+{
+  echo "Common settings:"
+  echo "  --tracing                  Enable ICU tracing"
+  echo "  --help                     Print help and exit (short: -h)"
+  echo ""
+}
+
+properties=
+
+while [[ $# > 0 ]]; do
+  opt="$(echo "${1/#--/-}" | awk '{print tolower($0)}')"
+  case "$opt" in
+    -help|-h)
+      usage
+      exit 0
+      ;;
+    -tracing)
+      properties="$properties /p:IcuTracing=true"
+      ;;
+    *)
+      echo "Invalid argument: $1"
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
-"$scriptroot/eng/common/build.sh" --build --restore $@
+
+echo $tracing
+"$scriptroot/eng/common/build.sh" --build --restore $properties $@

--- a/eng/icu.mk
+++ b/eng/icu.mk
@@ -22,7 +22,7 @@ $(HOST_BUILDDIR)/.stamp-host: $(HOST_BUILDDIR)/.stamp-configure-host
 
 $(HOST_BUILDDIR)/.stamp-configure-host: | $(HOST_BUILDDIR)
 	cd $(HOST_BUILDDIR) && $(TOP)/icu/icu4c/source/configure \
-	--prefix=$(HOST_BINDIR) --disable-icu-config --disable-tools --disable-extras --disable-tests --disable-samples
+	--prefix=$(HOST_BINDIR) --disable-icu-config --disable-icuio --disable-extras --disable-tests --disable-samples
 	touch $@
 
 $(WASM_BUILDDIR):
@@ -37,7 +37,6 @@ ICU_DEFINES= \
 	-DUCONFIG_NO_FILTERED_BREAK_ITERATION=1 \
 	-DUCONFIG_NO_REGULAR_EXPRESSIONS=1 \
 	-DUCONFIG_NO_TRANSLITERATION=1 \
-	-DUCONFIG_NO_CONVERSION=1 \
 	-DUCONFIG_NO_FILE_IO=1 \
 	-DU_CHARSET_IS_UTF8=1 \
 	-DU_CHECK_DYLOAD=0 \
@@ -55,10 +54,10 @@ $(WASM_BUILDDIR)/.stamp-configure-wasm: $(HOST_BUILDDIR)/.stamp-host | $(WASM_BU
 	--prefix=$(WASM_BINDIR) \
 	--enable-static \
 	--disable-shared \
-	--disable-tools \
 	--disable-tests \
 	--disable-extras \
 	--disable-samples \
+	--disable-icuio \
 	--disable-renaming \
 	--disable-icu-config \
 	--with-cross-build=$(HOST_BUILDDIR) \

--- a/eng/icu.mk
+++ b/eng/icu.mk
@@ -21,7 +21,8 @@ $(HOST_BUILDDIR)/.stamp-host: $(HOST_BUILDDIR)/.stamp-configure-host
 	touch $@
 
 $(HOST_BUILDDIR)/.stamp-configure-host: | $(HOST_BUILDDIR)
-	cd $(HOST_BUILDDIR) && $(TOP)/icu/icu4c/source/configure --prefix=$(HOST_BINDIR) --disable-icu-config
+	cd $(HOST_BUILDDIR) && $(TOP)/icu/icu4c/source/configure \
+	--prefix=$(HOST_BINDIR) --disable-icu-config --disable-tools --disable-extras --disable-tests --disable-samples
 	touch $@
 
 $(WASM_BUILDDIR):
@@ -31,7 +32,38 @@ $(WASM_BUILDDIR):
 icu-wasm: $(WASM_BUILDDIR)/.stamp-configure-wasm
 	cd $(WASM_BUILDDIR) && $(MAKE) -j8 all && $(MAKE) install
 
+# Disable some features we don't need, see icu/icu4c/source/common/unicode/uconfig.h
+ICU_DEFINES= \
+	-DUCONFIG_NO_FILTERED_BREAK_ITERATION=1 \
+	-DUCONFIG_NO_REGULAR_EXPRESSIONS=1 \
+	-DUCONFIG_NO_TRANSLITERATION=1 \
+	-DUCONFIG_NO_CONVERSION=1 \
+	-DUCONFIG_NO_FILE_IO=1 \
+	-DU_CHARSET_IS_UTF8=1 \
+	-DU_CHECK_DYLOAD=0 \
+	-DU_ENABLE_DYLOAD=0
+
+CONFIGURE_ADD_ARGS=
+ifeq ($(ICU_TRACING),true)
+    CONFIGURE_ADD_ARGS += --enable-tracing
+endif
+
 $(WASM_BUILDDIR)/.stamp-configure-wasm: $(HOST_BUILDDIR)/.stamp-host | $(WASM_BUILDDIR) check-env
-	cd $(WASM_BUILDDIR) && source $(EMSDK_PATH)/emsdk_env.sh && ICU_DATA_FILTER_FILE=$(ICU_FILTERS)/optimal.json \
-	emconfigure $(TOP)/icu/icu4c/source/configure --prefix=$(WASM_BINDIR) --enable-static --disable-shared CFLAGS="-Oz" CXXFLAGS="-Oz -Wno-sign-compare" --with-cross-build=$(HOST_BUILDDIR) --disable-icu-config --with-data-packaging=archive --disable-extras --disable-renaming
+	cd $(WASM_BUILDDIR) && source $(EMSDK_PATH)/emsdk_env.sh && \
+	ICU_DATA_FILTER_FILE=$(ICU_FILTERS)/optimal.json \
+	emconfigure $(TOP)/icu/icu4c/source/configure \
+	--prefix=$(WASM_BINDIR) \
+	--enable-static \
+	--disable-shared \
+	--disable-tools \
+	--disable-tests \
+	--disable-extras \
+	--disable-samples \
+	--disable-renaming \
+	--disable-icu-config \
+	--with-cross-build=$(HOST_BUILDDIR) \
+	--with-data-packaging=archive \
+	$(CONFIGURE_ADD_ARGS) \
+	CFLAGS="-Oz $(ICU_DEFINES)" \
+	CXXFLAGS="-fno-exceptions -Oz -Wno-sign-compare $(ICU_DEFINES)"
 	touch $@

--- a/eng/icu.proj
+++ b/eng/icu.proj
@@ -2,7 +2,7 @@
   <!-- Only building for wasm is supported -->
   <Target Name="Build">
     <Exec WorkingDirectory="$(MSBuildThisFileDirectory)"
-          Command="make -f icu.mk all ICU_TRACING=$(IcuTracing) SHELL=/bin/bash $(IcuConfigureArgs)"
+          Command="make -f icu.mk all ICU_TRACING=$(IcuTracing) SHELL=/bin/bash"
           IgnoreStandardErrorWarningFormat="true" />
   </Target>
   <Target Name="Restore" />

--- a/eng/icu.proj
+++ b/eng/icu.proj
@@ -2,7 +2,7 @@
   <!-- Only building for wasm is supported -->
   <Target Name="Build">
     <Exec WorkingDirectory="$(MSBuildThisFileDirectory)"
-          Command="make -f icu.mk all SHELL=/bin/bash"
+          Command="make -f icu.mk all ICU_TRACING=$(IcuTracing) SHELL=/bin/bash $(IcuConfigureArgs)"
           IgnoreStandardErrorWarningFormat="true" />
   </Target>
   <Target Name="Restore" />


### PR DESCRIPTION
Adds optional "--tracing" argument to enable tracing, usage:
```
./build.sh --tracing
```

Also, turns off some features we definitely don't need
doesn't save much, ~40kb or so.