### PR TITLE
Add Japanese calendar for ja(ja_JP) locale.

### DIFF
--- a/icu-filters/icudt.json
+++ b/icu-filters/icudt.json
@@ -198,6 +198,19 @@
         {
             "categories": ["locales_tree"],
             "files": {
+                "whitelist": ["ja"]
+            },
+            "rules": [
+                "-/calendar/*",
+                "+/calendar/default",
+                "+/calendar/gregorian",
+                "+/calendar/generic",
+                "+/calendar/japanese"
+            ]
+        },
+        {
+            "categories": ["locales_tree"],
+            "files": {
                 "whitelist": [
                     "bn",
                     "et",


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/blob/master/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoTests.cs#L179-L182 test.

Adds 1kb.