### PR TITLE
Bump emscripten version to 2.0.1

### DIFF
--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -41,7 +41,7 @@ stages:
         pool:
           name: Hosted Ubuntu 1604
         container:
-          image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-webassembly-20200529220811-6a6da63
+          image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-webassembly-20200827125937-9740252
         steps:
         - bash: |
             ./build.sh --ci --restore --build --pack --configuration $(_BuildConfig) $(_InternalBuildArgs)

--- a/eng/icu.mk
+++ b/eng/icu.mk
@@ -68,3 +68,4 @@ $(WASM_BUILDDIR)/.stamp-configure-wasm: $(ICU_FILTER) $(HOST_BUILDDIR)/.stamp-ho
 	$(CONFIGURE_ADD_ARGS) \
 	CFLAGS="-Oz $(ICU_DEFINES)" \
 	CXXFLAGS="-fno-exceptions -Oz -Wno-sign-compare $(ICU_DEFINES)"
+	touch $@


### PR DESCRIPTION
Updates the emscripten Docker container we use to build in CI.

Also fixes a small issue where we'd always run configure again since we didn't `touch` the stamp file.
