### PR TITLE
Fix datetime formats for KN and several other locales

### DIFF
--- a/icu-filters/icudt.json
+++ b/icu-filters/icudt.json
@@ -179,30 +179,6 @@
             ]
         },
         {
-            "categories": ["locales_tree"],
-            "files": {
-                "whitelist": [
-                    "bn",
-                    "et",
-                    "gu",
-                    "kn",
-                    "ml",
-                    "mr",
-                    "ms",
-                    "no",
-                    "ta",
-                    "te"
-                ]
-            },
-            "rules": [
-                "-/*",
-                "+/%%ALIAS",
-                "+/LocaleScript",
-                "+/layout",
-                "+/Version"
-            ]
-        },
-        {
             "categories": ["coll_tree"],
             "rules": [
                 "-/*/*",

--- a/icu-filters/icudt_no_CJK.json
+++ b/icu-filters/icudt_no_CJK.json
@@ -158,30 +158,6 @@
             ]
         },
         {
-            "categories": ["locales_tree"],
-            "files": {
-                "whitelist": [
-                    "bn",
-                    "et",
-                    "gu",
-                    "kn",
-                    "ml",
-                    "mr",
-                    "ms",
-                    "no",
-                    "ta",
-                    "te"
-                ]
-            },
-            "rules": [
-                "-/*",
-                "+/%%ALIAS",
-                "+/LocaleScript",
-                "+/layout",
-                "+/Version"
-            ]
-        },
-        {
             "categories": ["coll_tree"],
             "rules": [
                 "-/*/*",


### PR DESCRIPTION
Adds ~6 kb to the size after compression but fixes date time formats for these cultures, e.g. `kn`
```csharp
CultureInfo.CurrentCulture = new CultureInfo("kn");
Console.WriteLine(DateTime.Now.ToString());
```
is expected to return
```
"10/9/2020 07:49:42 ಅಪರಾಹ್ನ"
```
but was:
```
2020-09-10 16:50:45 (ISO)
```