### PR TITLE
[release/5.0] Add Japanese calendar for ja(ja_JP) locale.

### DIFF
--- a/icu-filters/icudt.json
+++ b/icu-filters/icudt.json
@@ -168,6 +168,19 @@
         {
             "categories": ["locales_tree"],
             "files": {
+                "whitelist": ["ja"]
+            },
+            "rules": [
+                "-/calendar/*",
+                "+/calendar/default",
+                "+/calendar/gregorian",
+                "+/calendar/generic",
+                "+/calendar/japanese"
+            ]
+        },
+        {
+            "categories": ["locales_tree"],
+            "files": {
                 "whitelist": [
                     "bn",
                     "et",


### PR DESCRIPTION
Backports https://github.com/dotnet/icu/pull/25 to 5.0

nuget: 5.0.0-rc.1.20467.1