### PR TITLE
Add exclusion for Microsoft.NETCore.Runtime.ICU.Transport

### DIFF
--- a/eng/SignCheckExclusionsFile.txt
+++ b/eng/SignCheckExclusionsFile.txt
@@ -1,5 +1,4 @@
 ;; Exclusions for SignCheck.
 ;; Format: https://github.com/dotnet/arcade/blob/397316e195639450b6c76bfeb9823b40bee72d6d/src/SignCheck/Microsoft.SignCheck/Verification/Exclusion.cs#L23-L35
 
-
 Microsoft.NETCore.Runtime.ICU.Transport.*.nupkg;;Transport package which does not get signed

--- a/eng/SignCheckExclusionsFile.txt
+++ b/eng/SignCheckExclusionsFile.txt
@@ -1,6 +1,5 @@
-;; Exclusions for SignCheck. Corresponds to info in Signing.props.
+;; Exclusions for SignCheck.
 ;; Format: https://github.com/dotnet/arcade/blob/397316e195639450b6c76bfeb9823b40bee72d6d/src/SignCheck/Microsoft.SignCheck/Verification/Exclusion.cs#L23-L35
-;;
-;; This issue tracks a way to implement exclusions via Signing.props and avoid this extra file: https://github.com/dotnet/arcade/issues/2888
+
 
 Microsoft.NETCore.Runtime.ICU.Transport.*.nupkg;;Transport package which does not get signed

--- a/eng/SignCheckExclusionsFile.txt
+++ b/eng/SignCheckExclusionsFile.txt
@@ -1,0 +1,6 @@
+;; Exclusions for SignCheck. Corresponds to info in Signing.props.
+;; Format: https://github.com/dotnet/arcade/blob/397316e195639450b6c76bfeb9823b40bee72d6d/src/SignCheck/Microsoft.SignCheck/Verification/Exclusion.cs#L23-L35
+;;
+;; This issue tracks a way to implement exclusions via Signing.props and avoid this extra file: https://github.com/dotnet/arcade/issues/2888
+
+Microsoft.NETCore.Runtime.ICU.Transport.*.nupkg;;Transport package which does not get signed


### PR DESCRIPTION
:warning: Please make sure your change cannot be made in the upstream ICU project first.
(then delete these lines)

<!--
Thanks for creating a pull request! We appreciate you taking the time to contribute!

Please note that this is a fork of ICU that contains changes for the following:
- Maintenance related changes.
- Changes that are required for usage internal to Microsoft.
- Changes that are needed for the Windows OS build of ICU.
- Changes to address the set of locales provided by Windows NLS compared to ICU.

Before creating any pull request, please ensure that your change is related to one of the above reasons.

Most other changes, bug fixes, improvements, enhancements, etc. should be made in the upstream project here:
https://github.com/unicode-org/icu

-->

<!-- Enter a brief description/summary of your PR here. What does it fix, what does it change, how was it tested... -->
## Summary
Add `Microsoft.NETCore.Runtime.ICU.Transport` to exclusion file so it does not fail internal validation processes

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [ ] I have verified that my change is specific to this fork and cannot be made upstream.
* [x] I am making a maintenance related change.
* [x] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description
Signing validation in the release pipeline is [failing](https://dnceng.visualstudio.com/internal/_build/results?buildId=860387&view=logs&j=452af998-e215-5aab-e7ec-c9cea27c3da1&t=de4773db-3311-5d9f-4eeb-3172b96a7ced) because this file is not getting signed.  This package appears to be an internal only package and should not be included in SignCheck.

FYI @mmitche @adiaaida 