### PR TITLE
Add libicudata to iOS & Android transport packages

### DIFF
--- a/eng/nuget/Microsoft.NETCore.Runtime.ICU.Transport.pkgproj
+++ b/eng/nuget/Microsoft.NETCore.Runtime.ICU.Transport.pkgproj
@@ -44,6 +44,7 @@
   <ItemGroup Condition="'$(AddAllTargetOSToPackage)' == 'true' or '$(PackageRID)' == 'android-x64'">
     <File Include="$(RepoRoot)\artifacts\bin\icu-android-x64\lib\libicui18n.a" TargetPath="runtimes\android-x64\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
     <File Include="$(RepoRoot)\artifacts\bin\icu-android-x64\lib\libicuuc.a" TargetPath="runtimes\android-x64\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
+    <File Include="$(RepoRoot)\artifacts\bin\icu-android-x64\lib\libicudata.a" TargetPath="runtimes\android-x64\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
     <File Include="$(RepoRoot)\artifacts\bin\icu-android-x64\include\**" TargetPath="runtimes\android-x64\native\include\%(RecursiveDir)%(Filename)%(Extension)" SkipPackageFileCheck="true" />
     <File Include="$(RepoRoot)\artifacts\bin\icu-android-x64\*.dat" TargetPath="runtimes\android-x64\native\lib\%(Filename).dat" SkipPackageFileCheck="true" />
   </ItemGroup>
@@ -51,6 +52,7 @@
   <ItemGroup Condition="'$(AddAllTargetOSToPackage)' == 'true' or '$(PackageRID)' == 'android-x86'">
     <File Include="$(RepoRoot)\artifacts\bin\icu-android-x86\lib\libicui18n.a" TargetPath="runtimes\android-x86\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
     <File Include="$(RepoRoot)\artifacts\bin\icu-android-x86\lib\libicuuc.a" TargetPath="runtimes\android-x86\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
+    <File Include="$(RepoRoot)\artifacts\bin\icu-android-x86\lib\libicudata.a" TargetPath="runtimes\android-x86\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
     <File Include="$(RepoRoot)\artifacts\bin\icu-android-x86\include\**" TargetPath="runtimes\android-x86\native\include\%(RecursiveDir)%(Filename)%(Extension)" SkipPackageFileCheck="true" />
     <File Include="$(RepoRoot)\artifacts\bin\icu-android-x86\*.dat" TargetPath="runtimes\android-x86\native\lib\%(Filename).dat" SkipPackageFileCheck="true" />
   </ItemGroup>
@@ -58,6 +60,7 @@
   <ItemGroup Condition="'$(AddAllTargetOSToPackage)' == 'true' or '$(PackageRID)' == 'android-arm64'">
     <File Include="$(RepoRoot)\artifacts\bin\icu-android-arm64\lib\libicui18n.a" TargetPath="runtimes\android-arm64\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
     <File Include="$(RepoRoot)\artifacts\bin\icu-android-arm64\lib\libicuuc.a" TargetPath="runtimes\android-arm64\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
+    <File Include="$(RepoRoot)\artifacts\bin\icu-android-arm64\lib\libicudata.a" TargetPath="runtimes\android-arm64\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
     <File Include="$(RepoRoot)\artifacts\bin\icu-android-arm64\include\**" TargetPath="runtimes\android-arm64\native\include\%(RecursiveDir)%(Filename)%(Extension)" SkipPackageFileCheck="true" />
     <File Include="$(RepoRoot)\artifacts\bin\icu-android-arm64\*.dat" TargetPath="runtimes\android-arm64\native\lib\%(Filename).dat" SkipPackageFileCheck="true" />
   </ItemGroup>
@@ -65,6 +68,7 @@
   <ItemGroup Condition="'$(AddAllTargetOSToPackage)' == 'true' or '$(PackageRID)' == 'android-arm'">
     <File Include="$(RepoRoot)\artifacts\bin\icu-android-arm\lib\libicui18n.a" TargetPath="runtimes\android-arm\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
     <File Include="$(RepoRoot)\artifacts\bin\icu-android-arm\lib\libicuuc.a" TargetPath="runtimes\android-arm\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
+    <File Include="$(RepoRoot)\artifacts\bin\icu-android-arm\lib\libicudata.a" TargetPath="runtimes\android-arm\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
     <File Include="$(RepoRoot)\artifacts\bin\icu-android-arm\include\**" TargetPath="runtimes\android-arm\native\include\%(RecursiveDir)%(Filename)%(Extension)" SkipPackageFileCheck="true" />
     <File Include="$(RepoRoot)\artifacts\bin\icu-android-arm\*.dat" TargetPath="runtimes\android-arm\native\lib\%(Filename).dat" SkipPackageFileCheck="true" />
   </ItemGroup>
@@ -73,6 +77,7 @@
   <ItemGroup Condition="'$(AddAllTargetOSToPackage)' == 'true' or '$(PackageRID)' == 'ios-x64'">
     <File Include="$(RepoRoot)\artifacts\bin\icu-ios-x64\lib\libicui18n.a" TargetPath="runtimes\ios-x64\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
     <File Include="$(RepoRoot)\artifacts\bin\icu-ios-x64\lib\libicuuc.a" TargetPath="runtimes\ios-x64\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
+    <File Include="$(RepoRoot)\artifacts\bin\icu-ios-x64\lib\libicudata.a" TargetPath="runtimes\ios-x64\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
     <File Include="$(RepoRoot)\artifacts\bin\icu-ios-x64\include\**" TargetPath="runtimes\ios-x64\native\include\%(RecursiveDir)%(Filename)%(Extension)" SkipPackageFileCheck="true" />
     <File Include="$(RepoRoot)\artifacts\bin\icu-ios-x64\*.dat" TargetPath="runtimes\ios-x64\native\lib\%(Filename).dat" SkipPackageFileCheck="true" />
   </ItemGroup>
@@ -80,6 +85,7 @@
   <ItemGroup Condition="'$(AddAllTargetOSToPackage)' == 'true' or '$(PackageRID)' == 'ios-x86'">
     <File Include="$(RepoRoot)\artifacts\bin\icu-ios-x86\lib\libicui18n.a" TargetPath="runtimes\ios-x86\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
     <File Include="$(RepoRoot)\artifacts\bin\icu-ios-x86\lib\libicuuc.a" TargetPath="runtimes\ios-x86\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
+    <File Include="$(RepoRoot)\artifacts\bin\icu-ios-x86\lib\libicudata.a" TargetPath="runtimes\ios-x86\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
     <File Include="$(RepoRoot)\artifacts\bin\icu-ios-x86\include\**" TargetPath="runtimes\ios-x86\native\include\%(RecursiveDir)%(Filename)%(Extension)" SkipPackageFileCheck="true" />
     <File Include="$(RepoRoot)\artifacts\bin\icu-ios-x86\*.dat" TargetPath="runtimes\ios-x86\native\lib\%(Filename).dat" SkipPackageFileCheck="true" />
   </ItemGroup>
@@ -87,6 +93,7 @@
   <ItemGroup Condition="'$(AddAllTargetOSToPackage)' == 'true' or '$(PackageRID)' == 'ios-arm64'">
     <File Include="$(RepoRoot)\artifacts\bin\icu-ios-arm64\lib\libicui18n.a" TargetPath="runtimes\ios-arm64\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
     <File Include="$(RepoRoot)\artifacts\bin\icu-ios-arm64\lib\libicuuc.a" TargetPath="runtimes\ios-arm64\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
+    <File Include="$(RepoRoot)\artifacts\bin\icu-ios-arm64\lib\libicudata.a" TargetPath="runtimes\ios-arm64\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
     <File Include="$(RepoRoot)\artifacts\bin\icu-ios-arm64\include\**" TargetPath="runtimes\ios-arm64\native\include\%(RecursiveDir)%(Filename)%(Extension)" SkipPackageFileCheck="true" />
     <File Include="$(RepoRoot)\artifacts\bin\icu-ios-arm64\*.dat" TargetPath="runtimes\ios-arm64\native\lib\%(Filename).dat" SkipPackageFileCheck="true" />
   </ItemGroup>
@@ -94,6 +101,7 @@
   <ItemGroup Condition="'$(AddAllTargetOSToPackage)' == 'true' or '$(PackageRID)' == 'ios-arm'">
     <File Include="$(RepoRoot)\artifacts\bin\icu-ios-arm\lib\libicui18n.a" TargetPath="runtimes\ios-arm\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
     <File Include="$(RepoRoot)\artifacts\bin\icu-ios-arm\lib\libicuuc.a" TargetPath="runtimes\ios-arm\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
+    <File Include="$(RepoRoot)\artifacts\bin\icu-ios-arm\lib\libicudata.a" TargetPath="runtimes\ios-arm\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
     <File Include="$(RepoRoot)\artifacts\bin\icu-ios-arm\include\**" TargetPath="runtimes\ios-arm\native\include\%(RecursiveDir)%(Filename)%(Extension)" SkipPackageFileCheck="true" />
     <File Include="$(RepoRoot)\artifacts\bin\icu-ios-arm\*.dat" TargetPath="runtimes\ios-arm\native\lib\%(Filename).dat" SkipPackageFileCheck="true" />
   </ItemGroup>
@@ -102,6 +110,7 @@
   <ItemGroup Condition="'$(AddAllTargetOSToPackage)' == 'true' or '$(PackageRID)' == 'tvos-x64'">
     <File Include="$(RepoRoot)\artifacts\bin\icu-tvos-x64\lib\libicui18n.a" TargetPath="runtimes\tvos-x64\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
     <File Include="$(RepoRoot)\artifacts\bin\icu-tvos-x64\lib\libicuuc.a" TargetPath="runtimes\tvos-x64\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
+    <File Include="$(RepoRoot)\artifacts\bin\icu-tvos-x64\lib\libicudata.a" TargetPath="runtimes\tvos-x64\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
     <File Include="$(RepoRoot)\artifacts\bin\icu-tvos-x64\include\**" TargetPath="runtimes\tvos-x64\native\include\%(RecursiveDir)%(Filename)%(Extension)" SkipPackageFileCheck="true" />
     <File Include="$(RepoRoot)\artifacts\bin\icu-tvos-x64\*.dat" TargetPath="runtimes\tvos-x64\native\lib\%(Filename).dat" SkipPackageFileCheck="true" />
   </ItemGroup>
@@ -109,6 +118,7 @@
   <ItemGroup Condition="'$(AddAllTargetOSToPackage)' == 'true' or '$(PackageRID)' == 'tvos-arm64'">
     <File Include="$(RepoRoot)\artifacts\bin\icu-tvos-arm64\lib\libicui18n.a" TargetPath="runtimes\tvos-arm64\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
     <File Include="$(RepoRoot)\artifacts\bin\icu-tvos-arm64\lib\libicuuc.a" TargetPath="runtimes\tvos-arm64\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
+    <File Include="$(RepoRoot)\artifacts\bin\icu-tvos-arm64\lib\libicudata.a" TargetPath="runtimes\tvos-arm64\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
     <File Include="$(RepoRoot)\artifacts\bin\icu-tvos-arm64\include\**" TargetPath="runtimes\tvos-arm64\native\include\%(RecursiveDir)%(Filename)%(Extension)" SkipPackageFileCheck="true" />
     <File Include="$(RepoRoot)\artifacts\bin\icu-tvos-arm64\*.dat" TargetPath="runtimes\tvos-arm64\native\lib\%(Filename).dat" SkipPackageFileCheck="true" />
   </ItemGroup>


### PR DESCRIPTION
Make sure libicudata.a comes along in the transport packages.  iOS and Android seem to need it to link properly.

Once we figure out if there's a way to exclude the data library outright, then we can revert this commit.
