### PR TITLE
Rename iOS/tvOS rids to match upcoming changes in dotnet/runtime

### DIFF
--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -56,8 +56,9 @@ stages:
           vmImage: macOS-10.15
         steps:
         - bash: |
-            ./build.sh --ci --restore --build --configuration $(_BuildConfig) /p:TargetOS=iOS /p:TargetArchitecture=x64 $(_InternalBuildArgs)
-            ./build.sh --ci --restore --build --configuration $(_BuildConfig) /p:TargetOS=iOS /p:TargetArchitecture=x86 $(_InternalBuildArgs)
+            ./build.sh --ci --restore --build --configuration $(_BuildConfig) /p:TargetOS=iOS-sim /p:TargetArchitecture=x64 $(_InternalBuildArgs)
+            ./build.sh --ci --restore --build --configuration $(_BuildConfig) /p:TargetOS=iOS-sim /p:TargetArchitecture=x86 $(_InternalBuildArgs)
+            ./build.sh --ci --restore --build --configuration $(_BuildConfig) /p:TargetOS=iOS-sim /p:TargetArchitecture=arm64 $(_InternalBuildArgs)
             ./build.sh --ci --restore --build --configuration $(_BuildConfig) /p:TargetOS=iOS /p:TargetArchitecture=arm64 $(_InternalBuildArgs)
             ./build.sh --ci --restore --build --configuration $(_BuildConfig) /p:TargetOS=iOS /p:TargetArchitecture=arm $(_InternalBuildArgs)
           displayName: Build
@@ -76,7 +77,8 @@ stages:
           vmImage: macOS-10.15
         steps:
         - bash: |
-            ./build.sh --ci --restore --build --configuration $(_BuildConfig) /p:TargetOS=tvOS /p:TargetArchitecture=x64 $(_InternalBuildArgs)
+            ./build.sh --ci --restore --build --configuration $(_BuildConfig) /p:TargetOS=tvOS-sim /p:TargetArchitecture=x64 $(_InternalBuildArgs)
+            ./build.sh --ci --restore --build --configuration $(_BuildConfig) /p:TargetOS=tvOS-sim /p:TargetArchitecture=arm64 $(_InternalBuildArgs)
             ./build.sh --ci --restore --build --configuration $(_BuildConfig) /p:TargetOS=tvOS /p:TargetArchitecture=arm64 $(_InternalBuildArgs)
           displayName: Build
         - task: PublishPipelineArtifact@1

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -51,7 +51,7 @@ stages:
       ############ iOS BUILD ############
       - job: Build_iOS
         displayName: iOS
-        timeoutInMinutes: 30
+        timeoutInMinutes: 45
         pool:
           vmImage: macOS-10.15
         steps:

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -81,6 +81,7 @@ stages:
           vmImage: macOS-10.15
         steps:
         - bash: |
+            ./build.sh --ci --restore --build --configuration $(_BuildConfig) /p:TargetOS=tvOS-sim /p:TargetArchitecture=x64 $(_InternalBuildArgs)
             ./build.sh --ci --restore --build --configuration $(_BuildConfig) /p:TargetOS=tvOS-sim /p:TargetArchitecture=arm64 $(_InternalBuildArgs)
             ./build.sh --ci --restore --build --configuration $(_BuildConfig) /p:TargetOS=tvOS /p:TargetArchitecture=arm64 $(_InternalBuildArgs)
             ### delete this entry after https://github.com/dotnet/runtime/pull/49305 is merged ##

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -61,6 +61,10 @@ stages:
             ./build.sh --ci --restore --build --configuration $(_BuildConfig) /p:TargetOS=iOS-sim /p:TargetArchitecture=arm64 $(_InternalBuildArgs)
             ./build.sh --ci --restore --build --configuration $(_BuildConfig) /p:TargetOS=iOS /p:TargetArchitecture=arm64 $(_InternalBuildArgs)
             ./build.sh --ci --restore --build --configuration $(_BuildConfig) /p:TargetOS=iOS /p:TargetArchitecture=arm $(_InternalBuildArgs)
+            ### delete this entry after https://github.com/dotnet/runtime/pull/49305 is merged ##
+            ./build.sh --ci --restore --build --configuration $(_BuildConfig) /p:TargetOS=iOS /p:TargetArchitecture=x64 $(_InternalBuildArgs)
+            ### delete this entry after https://github.com/dotnet/runtime/pull/49305 is merged ##
+            ./build.sh --ci --restore --build --configuration $(_BuildConfig) /p:TargetOS=iOS /p:TargetArchitecture=x86 $(_InternalBuildArgs)
           displayName: Build
         - task: PublishPipelineArtifact@1
           displayName: Upload artifacts
@@ -77,9 +81,10 @@ stages:
           vmImage: macOS-10.15
         steps:
         - bash: |
-            ./build.sh --ci --restore --build --configuration $(_BuildConfig) /p:TargetOS=tvOS-sim /p:TargetArchitecture=x64 $(_InternalBuildArgs)
             ./build.sh --ci --restore --build --configuration $(_BuildConfig) /p:TargetOS=tvOS-sim /p:TargetArchitecture=arm64 $(_InternalBuildArgs)
             ./build.sh --ci --restore --build --configuration $(_BuildConfig) /p:TargetOS=tvOS /p:TargetArchitecture=arm64 $(_InternalBuildArgs)
+            ### delete this entry after https://github.com/dotnet/runtime/pull/49305 is merged ##
+            ./build.sh --ci --restore --build --configuration $(_BuildConfig) /p:TargetOS=tvOS /p:TargetArchitecture=x64 $(_InternalBuildArgs)
           displayName: Build
         - task: PublishPipelineArtifact@1
           displayName: Upload artifacts

--- a/eng/icu.ios-sim.mk
+++ b/eng/icu.ios-sim.mk
@@ -1,18 +1,13 @@
 IOS_MIN_VERSION=8.0
 
-ifeq ($(TARGET_ARCHITECTURE),x64)
-	IOS_ARCH=-arch x86_64
-	IOS_SDK=iphonesimulator
-	IOS_ICU_HOST=i686-apple-darwin11
-endif
-ifeq ($(TARGET_ARCHITECTURE),x86)
-	IOS_ARCH=-arch i386
-	IOS_SDK=iphonesimulator
-	IOS_ICU_HOST=i686-apple-darwin11
-endif
 ifeq ($(TARGET_ARCHITECTURE),arm64)
 	IOS_ARCH=-arch arm64
-	IOS_SDK=iphonesimulator
+	IOS_SDK=iphoneos
+	IOS_ICU_HOST=arm-apple-darwin
+endif
+ifeq ($(TARGET_ARCHITECTURE),arm)
+	IOS_ARCH=-arch armv7 -arch armv7s
+	IOS_SDK=iphoneos
 	IOS_ICU_HOST=arm-apple-darwin
 endif
 

--- a/eng/icu.ios-sim.mk
+++ b/eng/icu.ios-sim.mk
@@ -1,13 +1,18 @@
 IOS_MIN_VERSION=8.0
 
+ifeq ($(TARGET_ARCHITECTURE),x64)
+	IOS_ARCH=-arch x86_64
+	IOS_SDK=iphonesimulator
+	IOS_ICU_HOST=i686-apple-darwin11
+endif
+ifeq ($(TARGET_ARCHITECTURE),x86)
+	IOS_ARCH=-arch i386
+	IOS_SDK=iphonesimulator
+	IOS_ICU_HOST=i686-apple-darwin11
+endif
 ifeq ($(TARGET_ARCHITECTURE),arm64)
 	IOS_ARCH=-arch arm64
-	IOS_SDK=iphoneos
-	IOS_ICU_HOST=arm-apple-darwin
-endif
-ifeq ($(TARGET_ARCHITECTURE),arm)
-	IOS_ARCH=-arch armv7 -arch armv7s
-	IOS_SDK=iphoneos
+	IOS_SDK=iphonesimulator
 	IOS_ICU_HOST=arm-apple-darwin
 endif
 

--- a/eng/icu.ios.mk
+++ b/eng/icu.ios.mk
@@ -1,18 +1,13 @@
 IOS_MIN_VERSION=8.0
 
-ifeq ($(TARGET_ARCHITECTURE),x64)
-	IOS_ARCH=-arch x86_64
-	IOS_SDK=iphonesimulator
-	IOS_ICU_HOST=i686-apple-darwin11
-endif
-ifeq ($(TARGET_ARCHITECTURE),x86)
-	IOS_ARCH=-arch i386
-	IOS_SDK=iphonesimulator
-	IOS_ICU_HOST=i686-apple-darwin11
-endif
 ifeq ($(TARGET_ARCHITECTURE),arm64)
 	IOS_ARCH=-arch arm64
-	IOS_SDK=iphonesimulator
+	IOS_SDK=iphoneos
+	IOS_ICU_HOST=arm-apple-darwin
+endif
+ifeq ($(TARGET_ARCHITECTURE),arm)
+	IOS_ARCH=-arch armv7 -arch armv7s
+	IOS_SDK=iphoneos
 	IOS_ICU_HOST=arm-apple-darwin
 endif
 

--- a/eng/icu.ios.mk
+++ b/eng/icu.ios.mk
@@ -1,5 +1,17 @@
 IOS_MIN_VERSION=8.0
 
+### Delete this when https://github.com/dotnet/runtime/pull/49305 is merged ###
+ifeq ($(TARGET_ARCHITECTURE),x64)
+	IOS_ARCH=-arch x86_64
+	IOS_SDK=iphonesimulator
+	IOS_ICU_HOST=i686-apple-darwin11
+endif
+### Delete this when https://github.com/dotnet/runtime/pull/49305 is merged ###
+ifeq ($(TARGET_ARCHITECTURE),x86)
+	IOS_ARCH=-arch i386
+	IOS_SDK=iphonesimulator
+	IOS_ICU_HOST=i686-apple-darwin11
+endif
 ifeq ($(TARGET_ARCHITECTURE),arm64)
 	IOS_ARCH=-arch arm64
 	IOS_SDK=iphoneos

--- a/eng/icu.tvos-sim.mk
+++ b/eng/icu.tvos-sim.mk
@@ -1,8 +1,13 @@
 TVOS_MIN_VERSION=9.0
 
+ifeq ($(TARGET_ARCHITECTURE),x64)
+	TVOS_ARCH=x86_64
+	TVOS_SDK=appletvsimulator
+	TVOS_ICU_HOST=i686-apple-darwin11
+endif
 ifeq ($(TARGET_ARCHITECTURE),arm64)
 	TVOS_ARCH=arm64
-	TVOS_SDK=appletvos
+	TVOS_SDK=appletvsimulator
 	TVOS_ICU_HOST=arm-apple-darwin
 endif
 

--- a/eng/icu.tvos.mk
+++ b/eng/icu.tvos.mk
@@ -1,5 +1,11 @@
 TVOS_MIN_VERSION=9.0
 
+### Delete this when https://github.com/dotnet/runtime/pull/49305 is merged ###
+ifeq ($(TARGET_ARCHITECTURE),x64)
+	TVOS_ARCH=x86_64
+	TVOS_SDK=appletvsimulator
+	TVOS_ICU_HOST=i686-apple-darwin11
+endif
 ifeq ($(TARGET_ARCHITECTURE),arm64)
 	TVOS_ARCH=arm64
 	TVOS_SDK=appletvos

--- a/eng/nuget/Microsoft.NETCore.Runtime.ICU.Transport.pkgproj
+++ b/eng/nuget/Microsoft.NETCore.Runtime.ICU.Transport.pkgproj
@@ -74,20 +74,28 @@
   </ItemGroup>
 
   <!-- iOS -->
-  <ItemGroup Condition="'$(AddAllTargetOSToPackage)' == 'true' or '$(PackageRID)' == 'ios-x64'">
-    <File Include="$(RepoRoot)\artifacts\bin\icu-ios-x64\lib\libicui18n.a" TargetPath="runtimes\ios-x64\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
-    <File Include="$(RepoRoot)\artifacts\bin\icu-ios-x64\lib\libicuuc.a" TargetPath="runtimes\ios-x64\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
-    <File Include="$(RepoRoot)\artifacts\bin\icu-ios-x64\lib\libicudata.a" TargetPath="runtimes\ios-x64\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
-    <File Include="$(RepoRoot)\artifacts\bin\icu-ios-x64\include\**" TargetPath="runtimes\ios-x64\native\include\%(RecursiveDir)%(Filename)%(Extension)" SkipPackageFileCheck="true" />
-    <File Include="$(RepoRoot)\artifacts\bin\icu-ios-x64\*.dat" TargetPath="runtimes\ios-x64\native\lib\%(Filename).dat" SkipPackageFileCheck="true" />
+  <ItemGroup Condition="'$(AddAllTargetOSToPackage)' == 'true' or '$(PackageRID)' == 'ios-sim-x64'">
+    <File Include="$(RepoRoot)\artifacts\bin\icu-ios-sim-x64\lib\libicui18n.a" TargetPath="runtimes\ios-sim-x64\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
+    <File Include="$(RepoRoot)\artifacts\bin\icu-ios-sim-x64\lib\libicuuc.a" TargetPath="runtimes\ios-sim-x64\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
+    <File Include="$(RepoRoot)\artifacts\bin\icu-ios-sim-x64\lib\libicudata.a" TargetPath="runtimes\ios-sim-x64\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
+    <File Include="$(RepoRoot)\artifacts\bin\icu-ios-sim-x64\include\**" TargetPath="runtimes\ios-sim-x64\native\include\%(RecursiveDir)%(Filename)%(Extension)" SkipPackageFileCheck="true" />
+    <File Include="$(RepoRoot)\artifacts\bin\icu-ios-sim-x64\*.dat" TargetPath="runtimes\ios-sim-x64\native\lib\%(Filename).dat" SkipPackageFileCheck="true" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(AddAllTargetOSToPackage)' == 'true' or '$(PackageRID)' == 'ios-x86'">
-    <File Include="$(RepoRoot)\artifacts\bin\icu-ios-x86\lib\libicui18n.a" TargetPath="runtimes\ios-x86\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
-    <File Include="$(RepoRoot)\artifacts\bin\icu-ios-x86\lib\libicuuc.a" TargetPath="runtimes\ios-x86\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
-    <File Include="$(RepoRoot)\artifacts\bin\icu-ios-x86\lib\libicudata.a" TargetPath="runtimes\ios-x86\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
-    <File Include="$(RepoRoot)\artifacts\bin\icu-ios-x86\include\**" TargetPath="runtimes\ios-x86\native\include\%(RecursiveDir)%(Filename)%(Extension)" SkipPackageFileCheck="true" />
-    <File Include="$(RepoRoot)\artifacts\bin\icu-ios-x86\*.dat" TargetPath="runtimes\ios-x86\native\lib\%(Filename).dat" SkipPackageFileCheck="true" />
+  <ItemGroup Condition="'$(AddAllTargetOSToPackage)' == 'true' or '$(PackageRID)' == 'ios-sim-x86'">
+    <File Include="$(RepoRoot)\artifacts\bin\icu-ios-sim-x86\lib\libicui18n.a" TargetPath="runtimes\ios-sim-x86\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
+    <File Include="$(RepoRoot)\artifacts\bin\icu-ios-sim-x86\lib\libicuuc.a" TargetPath="runtimes\ios-sim-x86\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
+    <File Include="$(RepoRoot)\artifacts\bin\icu-ios-sim-x86\lib\libicudata.a" TargetPath="runtimes\ios-sim-x86\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
+    <File Include="$(RepoRoot)\artifacts\bin\icu-ios-sim-x86\include\**" TargetPath="runtimes\ios-sim-x86\native\include\%(RecursiveDir)%(Filename)%(Extension)" SkipPackageFileCheck="true" />
+    <File Include="$(RepoRoot)\artifacts\bin\icu-ios-sim-x86\*.dat" TargetPath="runtimes\ios-sim-x86\native\lib\%(Filename).dat" SkipPackageFileCheck="true" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(AddAllTargetOSToPackage)' == 'true' or '$(PackageRID)' == 'ios-sim-arm64'">
+    <File Include="$(RepoRoot)\artifacts\bin\icu-ios-sim-arm64\lib\libicui18n.a" TargetPath="runtimes\ios-sim-arm64\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
+    <File Include="$(RepoRoot)\artifacts\bin\icu-ios-sim-arm64\lib\libicuuc.a" TargetPath="runtimes\ios-sim-arm64\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
+    <File Include="$(RepoRoot)\artifacts\bin\icu-ios-sim-arm64\lib\libicudata.a" TargetPath="runtimes\ios-sim-arm64\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
+    <File Include="$(RepoRoot)\artifacts\bin\icu-ios-sim-arm64\include\**" TargetPath="runtimes\ios-sim-arm64\native\include\%(RecursiveDir)%(Filename)%(Extension)" SkipPackageFileCheck="true" />
+    <File Include="$(RepoRoot)\artifacts\bin\icu-ios-sim-arm64\*.dat" TargetPath="runtimes\ios-sim-arm64\native\lib\%(Filename).dat" SkipPackageFileCheck="true" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(AddAllTargetOSToPackage)' == 'true' or '$(PackageRID)' == 'ios-arm64'">
@@ -107,12 +115,20 @@
   </ItemGroup>
 
   <!-- tvOS -->
-  <ItemGroup Condition="'$(AddAllTargetOSToPackage)' == 'true' or '$(PackageRID)' == 'tvos-x64'">
-    <File Include="$(RepoRoot)\artifacts\bin\icu-tvos-x64\lib\libicui18n.a" TargetPath="runtimes\tvos-x64\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
-    <File Include="$(RepoRoot)\artifacts\bin\icu-tvos-x64\lib\libicuuc.a" TargetPath="runtimes\tvos-x64\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
-    <File Include="$(RepoRoot)\artifacts\bin\icu-tvos-x64\lib\libicudata.a" TargetPath="runtimes\tvos-x64\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
-    <File Include="$(RepoRoot)\artifacts\bin\icu-tvos-x64\include\**" TargetPath="runtimes\tvos-x64\native\include\%(RecursiveDir)%(Filename)%(Extension)" SkipPackageFileCheck="true" />
-    <File Include="$(RepoRoot)\artifacts\bin\icu-tvos-x64\*.dat" TargetPath="runtimes\tvos-x64\native\lib\%(Filename).dat" SkipPackageFileCheck="true" />
+  <ItemGroup Condition="'$(AddAllTargetOSToPackage)' == 'true' or '$(PackageRID)' == 'tvos-sim-x64'">
+    <File Include="$(RepoRoot)\artifacts\bin\icu-tvos-sim-x64\lib\libicui18n.a" TargetPath="runtimes\tvos-sim-x64\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
+    <File Include="$(RepoRoot)\artifacts\bin\icu-tvos-sim-x64\lib\libicuuc.a" TargetPath="runtimes\tvos-sim-x64\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
+    <File Include="$(RepoRoot)\artifacts\bin\icu-tvos-sim-x64\lib\libicudata.a" TargetPath="runtimes\tvos-sim-x64\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
+    <File Include="$(RepoRoot)\artifacts\bin\icu-tvos-sim-x64\include\**" TargetPath="runtimes\tvos-sim-x64\native\include\%(RecursiveDir)%(Filename)%(Extension)" SkipPackageFileCheck="true" />
+    <File Include="$(RepoRoot)\artifacts\bin\icu-tvos-sim-x64\*.dat" TargetPath="runtimes\tvos-sim-x64\native\lib\%(Filename).dat" SkipPackageFileCheck="true" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(AddAllTargetOSToPackage)' == 'true' or '$(PackageRID)' == 'tvos-sim-arm64'">
+    <File Include="$(RepoRoot)\artifacts\bin\icu-tvos-sim-arm64\lib\libicui18n.a" TargetPath="runtimes\tvos-sim-arm64\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
+    <File Include="$(RepoRoot)\artifacts\bin\icu-tvos-sim-arm64\lib\libicuuc.a" TargetPath="runtimes\tvos-sim-arm64\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
+    <File Include="$(RepoRoot)\artifacts\bin\icu-tvos-sim-arm64\lib\libicudata.a" TargetPath="runtimes\tvos-sim-arm64\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
+    <File Include="$(RepoRoot)\artifacts\bin\icu-tvos-sim-arm64\include\**" TargetPath="runtimes\tvos-sim-arm64\native\include\%(RecursiveDir)%(Filename)%(Extension)" SkipPackageFileCheck="true" />
+    <File Include="$(RepoRoot)\artifacts\bin\icu-tvos-sim-arm64\*.dat" TargetPath="runtimes\tvos-sim-arm64\native\lib\%(Filename).dat" SkipPackageFileCheck="true" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(AddAllTargetOSToPackage)' == 'true' or '$(PackageRID)' == 'tvos-arm64'">

--- a/eng/nuget/Microsoft.NETCore.Runtime.ICU.Transport.pkgproj
+++ b/eng/nuget/Microsoft.NETCore.Runtime.ICU.Transport.pkgproj
@@ -74,6 +74,24 @@
   </ItemGroup>
 
   <!-- iOS -->
+  <!-- Delete this entry when https://github.com/dotnet/runtime/pull/49305 is merged -->
+  <ItemGroup Condition="'$(AddAllTargetOSToPackage)' == 'true' or '$(PackageRID)' == 'ios-x64'">
+    <File Include="$(RepoRoot)\artifacts\bin\icu-ios-x64\lib\libicui18n.a" TargetPath="runtimes\ios-x64\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
+    <File Include="$(RepoRoot)\artifacts\bin\icu-ios-x64\lib\libicuuc.a" TargetPath="runtimes\ios-x64\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
+    <File Include="$(RepoRoot)\artifacts\bin\icu-ios-x64\lib\libicudata.a" TargetPath="runtimes\ios-x64\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
+    <File Include="$(RepoRoot)\artifacts\bin\icu-ios-x64\include\**" TargetPath="runtimes\ios-x64\native\include\%(RecursiveDir)%(Filename)%(Extension)" SkipPackageFileCheck="true" />
+    <File Include="$(RepoRoot)\artifacts\bin\icu-ios-x64\*.dat" TargetPath="runtimes\ios-x64\native\lib\%(Filename).dat" SkipPackageFileCheck="true" />
+  </ItemGroup>
+
+  <!-- Delete this entry when https://github.com/dotnet/runtime/pull/49305 is merged -->
+  <ItemGroup Condition="'$(AddAllTargetOSToPackage)' == 'true' or '$(PackageRID)' == 'ios-x86'">
+    <File Include="$(RepoRoot)\artifacts\bin\icu-ios-x86\lib\libicui18n.a" TargetPath="runtimes\ios-x86\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
+    <File Include="$(RepoRoot)\artifacts\bin\icu-ios-x86\lib\libicuuc.a" TargetPath="runtimes\ios-x86\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
+    <File Include="$(RepoRoot)\artifacts\bin\icu-ios-x86\lib\libicudata.a" TargetPath="runtimes\ios-x86\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
+    <File Include="$(RepoRoot)\artifacts\bin\icu-ios-x86\include\**" TargetPath="runtimes\ios-x86\native\include\%(RecursiveDir)%(Filename)%(Extension)" SkipPackageFileCheck="true" />
+    <File Include="$(RepoRoot)\artifacts\bin\icu-ios-x86\*.dat" TargetPath="runtimes\ios-x86\native\lib\%(Filename).dat" SkipPackageFileCheck="true" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(AddAllTargetOSToPackage)' == 'true' or '$(PackageRID)' == 'ios-sim-x64'">
     <File Include="$(RepoRoot)\artifacts\bin\icu-ios-sim-x64\lib\libicui18n.a" TargetPath="runtimes\ios-sim-x64\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
     <File Include="$(RepoRoot)\artifacts\bin\icu-ios-sim-x64\lib\libicuuc.a" TargetPath="runtimes\ios-sim-x64\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
@@ -115,6 +133,15 @@
   </ItemGroup>
 
   <!-- tvOS -->
+  <!-- Delete this entry when https://github.com/dotnet/runtime/pull/49305 is merged -->
+  <ItemGroup Condition="'$(AddAllTargetOSToPackage)' == 'true' or '$(PackageRID)' == 'tvos-x64'">
+    <File Include="$(RepoRoot)\artifacts\bin\icu-tvos-x64\lib\libicui18n.a" TargetPath="runtimes\tvos-x64\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
+    <File Include="$(RepoRoot)\artifacts\bin\icu-tvos-x64\lib\libicuuc.a" TargetPath="runtimes\tvos-x64\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
+    <File Include="$(RepoRoot)\artifacts\bin\icu-tvos-x64\lib\libicudata.a" TargetPath="runtimes\tvos-x64\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
+    <File Include="$(RepoRoot)\artifacts\bin\icu-tvos-x64\include\**" TargetPath="runtimes\tvos-x64\native\include\%(RecursiveDir)%(Filename)%(Extension)" SkipPackageFileCheck="true" />
+    <File Include="$(RepoRoot)\artifacts\bin\icu-tvos-x64\*.dat" TargetPath="runtimes\tvos-x64\native\lib\%(Filename).dat" SkipPackageFileCheck="true" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(AddAllTargetOSToPackage)' == 'true' or '$(PackageRID)' == 'tvos-sim-x64'">
     <File Include="$(RepoRoot)\artifacts\bin\icu-tvos-sim-x64\lib\libicui18n.a" TargetPath="runtimes\tvos-sim-x64\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
     <File Include="$(RepoRoot)\artifacts\bin\icu-tvos-sim-x64\lib\libicuuc.a" TargetPath="runtimes\tvos-sim-x64\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />


### PR DESCRIPTION
This changes consolidates on the new iOS/tvOS RIDs, as per https://github.com/dotnet/runtime/pull/49305 and https://github.com/dotnet/runtime/issues/48216