### PR TITLE
Fix iOS/tvOS simulator builds actually being device builds, on arm64

### DIFF
--- a/eng/icu.ios.mk
+++ b/eng/icu.ios.mk
@@ -1,4 +1,4 @@
-IOS_MIN_VERSION=8.0
+IOS_MIN_VERSION=10.0
 
 ### Delete this when https://github.com/dotnet/runtime/pull/49305 is merged ###
 ifeq ($(TARGET_ARCHITECTURE),x64)

--- a/eng/icu.iossimulator.mk
+++ b/eng/icu.iossimulator.mk
@@ -1,27 +1,27 @@
-IOS_MIN_VERSION=8.0
+IOS_MIN_VERSION=10.0
 
 ifeq ($(TARGET_ARCHITECTURE),x64)
 	IOS_ARCH=-arch x86_64
 	IOS_SDK=iphonesimulator
-	IOS_ICU_HOST=i686-apple-darwin11
+	IOS_ICU_HOST=i686-apple-darwin
 endif
 ifeq ($(TARGET_ARCHITECTURE),x86)
 	IOS_ARCH=-arch i386
 	IOS_SDK=iphonesimulator
-	IOS_ICU_HOST=i686-apple-darwin11
+	IOS_ICU_HOST=i686-apple-darwin
 endif
 ifeq ($(TARGET_ARCHITECTURE),arm64)
 	IOS_ARCH=-arch arm64
 	IOS_SDK=iphonesimulator
-	IOS_ICU_HOST=arm-apple-darwin
+	IOS_ICU_HOST=aarch64-apple-darwin
 endif
 
 XCODE_DEVELOPER := $(shell xcode-select --print-path)
 XCODE_SDK := $(shell xcodebuild -version -sdk $(IOS_SDK) | grep -E '^Path' | sed 's/Path: //')
 
 CONFIGURE_COMPILER_FLAGS += \
-	CFLAGS="-Oz -fno-exceptions -Wno-sign-compare $(ICU_DEFINES) -isysroot $(XCODE_SDK) -I$(XCODE_SDK)/usr/include/ $(IOS_ARCH) -miphoneos-version-min=$(IOS_MIN_VERSION)" \
-	CXXFLAGS="-Oz -fno-exceptions -Wno-sign-compare $(ICU_DEFINES) -isysroot $(XCODE_SDK) -I$(XCODE_SDK)/usr/include/ -I./include/ $(IOS_ARCH) -miphoneos-version-min=$(IOS_MIN_VERSION)" \
+	CFLAGS="-Oz -fno-exceptions -Wno-sign-compare $(ICU_DEFINES) -isysroot $(XCODE_SDK) -I$(XCODE_SDK)/usr/include/ $(IOS_ARCH) -miphonesimulator-version-min=$(IOS_MIN_VERSION)" \
+	CXXFLAGS="-Oz -fno-exceptions -Wno-sign-compare $(ICU_DEFINES) -isysroot $(XCODE_SDK) -I$(XCODE_SDK)/usr/include/ -I./include/ $(IOS_ARCH) -miphonesimulator-version-min=$(IOS_MIN_VERSION)" \
 	LDFLAGS="-L$(XCODE_SDK)/usr/lib/ -isysroot $(XCODE_SDK) -miphoneos-version-min=$(IOS_MIN_VERSION)" \
 	CC="$(XCODE_DEVELOPER)/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang" \
 	CXX="$(XCODE_DEVELOPER)/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++"

--- a/eng/icu.tvos.mk
+++ b/eng/icu.tvos.mk
@@ -1,15 +1,15 @@
-TVOS_MIN_VERSION=9.0
+TVOS_MIN_VERSION=10.0
 
 ### Delete this when https://github.com/dotnet/runtime/pull/49305 is merged ###
 ifeq ($(TARGET_ARCHITECTURE),x64)
 	TVOS_ARCH=x86_64
 	TVOS_SDK=appletvsimulator
-	TVOS_ICU_HOST=i686-apple-darwin11
+	TVOS_ICU_HOST=i686-apple-darwin
 endif
 ifeq ($(TARGET_ARCHITECTURE),arm64)
 	TVOS_ARCH=arm64
 	TVOS_SDK=appletvos
-	TVOS_ICU_HOST=arm-apple-darwin
+	TVOS_ICU_HOST=aarch64-apple-darwin
 endif
 
 XCODE_DEVELOPER := $(shell xcode-select --print-path)

--- a/eng/icu.tvossimulator.mk
+++ b/eng/icu.tvossimulator.mk
@@ -1,22 +1,22 @@
-TVOS_MIN_VERSION=9.0
+TVOS_MIN_VERSION=10.0
 
 ifeq ($(TARGET_ARCHITECTURE),x64)
 	TVOS_ARCH=x86_64
 	TVOS_SDK=appletvsimulator
-	TVOS_ICU_HOST=i686-apple-darwin11
+	TVOS_ICU_HOST=i686-apple-darwin
 endif
 ifeq ($(TARGET_ARCHITECTURE),arm64)
 	TVOS_ARCH=arm64
 	TVOS_SDK=appletvsimulator
-	TVOS_ICU_HOST=arm-apple-darwin
+	TVOS_ICU_HOST=aarch64-apple-darwin
 endif
 
 XCODE_DEVELOPER := $(shell xcode-select --print-path)
 XCODE_SDK := $(shell xcodebuild -version -sdk $(TVOS_SDK) | grep -E '^Path' | sed 's/Path: //')
 
 CONFIGURE_COMPILER_FLAGS += \
-	CFLAGS="-Oz -fno-exceptions -Wno-sign-compare $(ICU_DEFINES) -isysroot $(XCODE_SDK) -I$(XCODE_SDK)/usr/include/ -arch $(TVOS_ARCH) -mappletvos-version-min=$(TVOS_MIN_VERSION)" \
-	CXXFLAGS="-Oz -fno-exceptions -Wno-sign-compare $(ICU_DEFINES) -isysroot $(XCODE_SDK) -I$(XCODE_SDK)/usr/include/ -I./include/ -arch $(TVOS_ARCH) -mappletvos-version-min=$(TVOS_MIN_VERSION)" \
+	CFLAGS="-Oz -fno-exceptions -Wno-sign-compare $(ICU_DEFINES) -isysroot $(XCODE_SDK) -I$(XCODE_SDK)/usr/include/ -arch $(TVOS_ARCH) -mappletvsimulator-version-min=$(TVOS_MIN_VERSION)" \
+	CXXFLAGS="-Oz -fno-exceptions -Wno-sign-compare $(ICU_DEFINES) -isysroot $(XCODE_SDK) -I$(XCODE_SDK)/usr/include/ -I./include/ -arch $(TVOS_ARCH) -mappletvsimulator-version-min=$(TVOS_MIN_VERSION)" \
 	LDFLAGS="-L$(XCODE_SDK)/usr/lib/ -isysroot $(XCODE_SDK) -mappletvos-version-min=$(TVOS_MIN_VERSION)" \
 	CC="$(XCODE_DEVELOPER)/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang" \
 	CXX="$(XCODE_DEVELOPER)/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++"


### PR DESCRIPTION
Ref: https://github.com/dotnet/runtime/issues/50005

Indispensable: the chart on https://github.com/rust-lang/rust/issues/48862