### PR TITLE
ICU-20684 Fix uninitialized in isMatchAtCPBoundary

### DIFF
--- a/icu/icu4c/source/common/ustring.cpp
+++ b/icu/icu4c/source/common/ustring.cpp
@@ -45,7 +45,7 @@ isMatchAtCPBoundary(const UChar *start, const UChar *match, const UChar *matchLi
         /* the leading edge of the match is in the middle of a surrogate pair */
         return FALSE;
     }
-    if(U16_IS_LEAD(*(matchLimit-1)) && match!=limit && U16_IS_TRAIL(*matchLimit)) {
+    if(U16_IS_LEAD(*(matchLimit-1)) && matchLimit!=limit && U16_IS_TRAIL(*matchLimit)) {
         /* the trailing edge of the match is in the middle of a surrogate pair */
         return FALSE;
     }

--- a/icu/icu4c/source/test/cintltst/custrtst.c
+++ b/icu/icu4c/source/test/cintltst/custrtst.c
@@ -962,6 +962,16 @@ TestSurrogateSearching() {
     ) {
         log_err("error: one of the u_str[str etc](\"aba\") incorrectly finds something\n");
     }
+    /* Regression test for ICU-20684 Use-of-uninitialized-value in isMatchAtCPBoundary
+     * Condition: search the same string while the first char is not an
+     * surrogate and the last char is the leading surragte.
+     */
+    {
+        static const UChar s[]={ 0x0020, 0xD9C1 };
+        if (u_strFindFirst(s, 2, s, 2) != s) {
+            log_err("error: ending with a partial supplementary code point should match\n");
+        }
+    }
 }
 
 static void TestStringCopy()


### PR DESCRIPTION
Downstream bug https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=15505
Fix Fuzzer-detected Use-of-uninitialized-value in isMatchAtCPBoundary

To test to show the bug in the new test case, configure and build with
CFLAGS="-fsanitize=memory" CXXFLAGS="-fsanitize=memory" ./runConfigureICU \
  --enable-debug --disable-release  Linux  --disable-layoutex

Test with
cintltst /tsutil/custrtst