### PR TITLE
fix: Add missing `libicudata.a` file from browser nuget package

### DIFF
--- a/eng/nuget/Microsoft.NETCore.Runtime.ICU.Transport.pkgproj
+++ b/eng/nuget/Microsoft.NETCore.Runtime.ICU.Transport.pkgproj
@@ -41,6 +41,7 @@
     <File Include="$(RepoRoot)\artifacts\bin\icu-browser-wasm\emscripten-version.txt" TargetPath="runtimes\browser-wasm\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
     <File Include="$(RepoRoot)\artifacts\bin\icu-browser-wasm\lib\libicui18n.a" TargetPath="runtimes\browser-wasm\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
     <File Include="$(RepoRoot)\artifacts\bin\icu-browser-wasm\lib\libicuuc.a" TargetPath="runtimes\browser-wasm\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
+    <File Include="$(RepoRoot)\artifacts\bin\icu-browser-wasm\lib\libicudata.a" TargetPath="runtimes\browser-wasm\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
     <File Include="$(RepoRoot)\artifacts\bin\icu-browser-wasm\include\**" TargetPath="runtimes\browser-wasm\native\include\%(RecursiveDir)%(Filename)%(Extension)" SkipPackageFileCheck="true" />
     <!-- Work around non-determinism reported in https://github.com/dotnet/runtime/issues/55637
          we cannot trust that the .dat files generated in a build are "good", so we prefer files
@@ -53,6 +54,7 @@
     <!-- Threads build -->
     <File Include="$(RepoRoot)\artifacts\bin\browser-threading\icu-browser-wasm\lib\libicui18n.a" TargetPath="runtimes\browser-wasm$(ExtraPackageName)\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
     <File Include="$(RepoRoot)\artifacts\bin\browser-threading\icu-browser-wasm\lib\libicuuc.a" TargetPath="runtimes\browser-wasm$(ExtraPackageName)\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
+    <File Include="$(RepoRoot)\artifacts\bin\browser-threading\icu-browser-wasm\lib\libicudata.a" TargetPath="runtimes\browser-wasm$(ExtraPackageName)\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
     <File Include="$(RepoRoot)\artifacts\bin\browser-threading\icu-browser-wasm\include\**" TargetPath="runtimes\browser-wasm$(ExtraPackageName)\native\include\%(RecursiveDir)%(Filename)%(Extension)" SkipPackageFileCheck="true" />
     <!-- Work around non-determinism reported in https://github.com/dotnet/runtime/issues/55637
          we cannot trust that the .dat files generated in a build are "good", so we prefer files


### PR DESCRIPTION
:warning: Please make sure your change cannot be made in the upstream ICU project first.
(then delete these lines)

<!--
Thanks for creating a pull request! We appreciate you taking the time to contribute!

Please note that this is a fork of ICU that contains changes for the following:
- Maintenance related changes.
- Changes that are required for usage internal to Microsoft.
- Changes that are needed for the Windows OS build of ICU.
- Changes to address the set of locales provided by Windows NLS compared to ICU.

Before creating any pull request, please ensure that your change is related to one of the above reasons.

Most other changes, bug fixes, improvements, enhancements, etc. should be made in the upstream project here:
https://github.com/unicode-org/icu

-->

<!-- Enter a brief description/summary of your PR here. What does it fix, what does it change, how was it tested... -->
## Summary

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [x] I have verified that my change is specific to this fork and cannot be made upstream.
* [ ] I am making a maintenance related change.
* [ ] I am making a change that is related to usage internal to Microsoft.
* [ ] I am making a change that is related to the Windows OS build of ICU.
* [x] CLA signed. If not, please see [here](https://cla.opensource.microsoft.com/microsoft/icu) to sign the CLA.

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description

For browser-wasm. the nuget package is missing libicudata, causing AOT builds to fail for the missing `icudt68_dat` symbol. This change includes this file.