### PR TITLE
Bump iOS/tvOS min version to 11, remove 32bit targets and remove bitcode from tvOS

### DIFF
--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -131,10 +131,8 @@ stages:
         steps:
         - bash: |
             ./build.sh --ci --restore --build --configuration $(_BuildConfig) /p:TargetOS=iOSSimulator /p:TargetArchitecture=x64 $(_InternalBuildArgs)
-            ./build.sh --ci --restore --build --configuration $(_BuildConfig) /p:TargetOS=iOSSimulator /p:TargetArchitecture=x86 $(_InternalBuildArgs)
             ./build.sh --ci --restore --build --configuration $(_BuildConfig) /p:TargetOS=iOSSimulator /p:TargetArchitecture=arm64 $(_InternalBuildArgs)
             ./build.sh --ci --restore --build --configuration $(_BuildConfig) /p:TargetOS=iOS /p:TargetArchitecture=arm64 $(_InternalBuildArgs)
-            ./build.sh --ci --restore --build --configuration $(_BuildConfig) /p:TargetOS=iOS /p:TargetArchitecture=arm $(_InternalBuildArgs)
           displayName: Build
         - task: PublishPipelineArtifact@1
           displayName: Upload artifacts

--- a/eng/icu.ios.mk
+++ b/eng/icu.ios.mk
@@ -1,24 +1,7 @@
-IOS_MIN_VERSION=10.0
+IOS_MIN_VERSION=11.0
 
-### Delete this when https://github.com/dotnet/runtime/pull/49305 is merged ###
-ifeq ($(TARGET_ARCHITECTURE),x64)
-	IOS_ARCH=-arch x86_64
-	IOS_SDK=iphonesimulator
-	IOS_ICU_HOST=i686-apple-darwin11
-endif
-### Delete this when https://github.com/dotnet/runtime/pull/49305 is merged ###
-ifeq ($(TARGET_ARCHITECTURE),x86)
-	IOS_ARCH=-arch i386
-	IOS_SDK=iphonesimulator
-	IOS_ICU_HOST=i686-apple-darwin11
-endif
 ifeq ($(TARGET_ARCHITECTURE),arm64)
-	IOS_ARCH=-arch arm64
-	IOS_SDK=iphoneos
-	IOS_ICU_HOST=arm-apple-darwin
-endif
-ifeq ($(TARGET_ARCHITECTURE),arm)
-	IOS_ARCH=-arch armv7 -arch armv7s
+	IOS_ARCH=arm64
 	IOS_SDK=iphoneos
 	IOS_ICU_HOST=arm-apple-darwin
 endif
@@ -27,8 +10,8 @@ XCODE_DEVELOPER := $(shell xcode-select --print-path)
 XCODE_SDK := $(shell xcodebuild -version -sdk $(IOS_SDK) | grep -E '^Path' | sed 's/Path: //')
 
 CONFIGURE_COMPILER_FLAGS += \
-	CFLAGS="-Oz -fno-exceptions -Wno-sign-compare $(ICU_DEFINES) -isysroot $(XCODE_SDK) -I$(XCODE_SDK)/usr/include/ $(IOS_ARCH) -miphoneos-version-min=$(IOS_MIN_VERSION)" \
-	CXXFLAGS="-Oz -fno-exceptions -Wno-sign-compare $(ICU_DEFINES) -isysroot $(XCODE_SDK) -I$(XCODE_SDK)/usr/include/ -I./include/ $(IOS_ARCH) -miphoneos-version-min=$(IOS_MIN_VERSION)" \
+	CFLAGS="-Oz -fno-exceptions -Wno-sign-compare $(ICU_DEFINES) -isysroot $(XCODE_SDK) -I$(XCODE_SDK)/usr/include/ -arch $(IOS_ARCH) -miphoneos-version-min=$(IOS_MIN_VERSION)" \
+	CXXFLAGS="-Oz -fno-exceptions -Wno-sign-compare $(ICU_DEFINES) -isysroot $(XCODE_SDK) -I$(XCODE_SDK)/usr/include/ -I./include/ -arch $(IOS_ARCH) -miphoneos-version-min=$(IOS_MIN_VERSION)" \
 	LDFLAGS="-L$(XCODE_SDK)/usr/lib/ -isysroot $(XCODE_SDK) -miphoneos-version-min=$(IOS_MIN_VERSION)" \
 	CC="$(XCODE_DEVELOPER)/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang" \
 	CXX="$(XCODE_DEVELOPER)/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++"

--- a/eng/icu.iossimulator.mk
+++ b/eng/icu.iossimulator.mk
@@ -1,17 +1,12 @@
-IOS_MIN_VERSION=10.0
+IOS_MIN_VERSION=11.0
 
 ifeq ($(TARGET_ARCHITECTURE),x64)
-	IOS_ARCH=-arch x86_64
+	IOS_ARCH=x86_64
 	IOS_SDK=iphonesimulator
-	IOS_ICU_HOST=i686-apple-darwin
-endif
-ifeq ($(TARGET_ARCHITECTURE),x86)
-	IOS_ARCH=-arch i386
-	IOS_SDK=iphonesimulator
-	IOS_ICU_HOST=i686-apple-darwin
+	IOS_ICU_HOST=x86_64-apple-darwin
 endif
 ifeq ($(TARGET_ARCHITECTURE),arm64)
-	IOS_ARCH=-arch arm64
+	IOS_ARCH=arm64
 	IOS_SDK=iphonesimulator
 	IOS_ICU_HOST=aarch64-apple-darwin
 endif
@@ -20,8 +15,8 @@ XCODE_DEVELOPER := $(shell xcode-select --print-path)
 XCODE_SDK := $(shell xcodebuild -version -sdk $(IOS_SDK) | grep -E '^Path' | sed 's/Path: //')
 
 CONFIGURE_COMPILER_FLAGS += \
-	CFLAGS="-Oz -fno-exceptions -Wno-sign-compare $(ICU_DEFINES) -isysroot $(XCODE_SDK) -I$(XCODE_SDK)/usr/include/ $(IOS_ARCH) -miphonesimulator-version-min=$(IOS_MIN_VERSION)" \
-	CXXFLAGS="-Oz -fno-exceptions -Wno-sign-compare $(ICU_DEFINES) -isysroot $(XCODE_SDK) -I$(XCODE_SDK)/usr/include/ -I./include/ $(IOS_ARCH) -miphonesimulator-version-min=$(IOS_MIN_VERSION)" \
+	CFLAGS="-Oz -fno-exceptions -Wno-sign-compare $(ICU_DEFINES) -isysroot $(XCODE_SDK) -I$(XCODE_SDK)/usr/include/ -arch $(IOS_ARCH) -miphonesimulator-version-min=$(IOS_MIN_VERSION)" \
+	CXXFLAGS="-Oz -fno-exceptions -Wno-sign-compare $(ICU_DEFINES) -isysroot $(XCODE_SDK) -I$(XCODE_SDK)/usr/include/ -I./include/ -arch $(IOS_ARCH) -miphonesimulator-version-min=$(IOS_MIN_VERSION)" \
 	LDFLAGS="-L$(XCODE_SDK)/usr/lib/ -isysroot $(XCODE_SDK) -miphoneos-version-min=$(IOS_MIN_VERSION)" \
 	CC="$(XCODE_DEVELOPER)/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang" \
 	CXX="$(XCODE_DEVELOPER)/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++"

--- a/eng/icu.tvos.mk
+++ b/eng/icu.tvos.mk
@@ -1,4 +1,4 @@
-TVOS_MIN_VERSION=10.0
+TVOS_MIN_VERSION=11.0
 
 ifeq ($(TARGET_ARCHITECTURE),arm64)
 	TVOS_ARCH=arm64
@@ -10,9 +10,9 @@ XCODE_DEVELOPER := $(shell xcode-select --print-path)
 XCODE_SDK := $(shell xcodebuild -version -sdk $(TVOS_SDK) | grep -E '^Path' | sed 's/Path: //')
 
 CONFIGURE_COMPILER_FLAGS += \
-	CFLAGS="-fembed-bitcode -Oz -fno-exceptions -Wno-sign-compare $(ICU_DEFINES) -isysroot $(XCODE_SDK) -I$(XCODE_SDK)/usr/include/ -arch $(TVOS_ARCH) -mappletvos-version-min=$(TVOS_MIN_VERSION)" \
-	CXXFLAGS="-fembed-bitcode -Oz -fno-exceptions -Wno-sign-compare $(ICU_DEFINES) -isysroot $(XCODE_SDK) -I$(XCODE_SDK)/usr/include/ -I./include/ -arch $(TVOS_ARCH) -mappletvos-version-min=$(TVOS_MIN_VERSION)" \
-	LDFLAGS="-fembed-bitcode -L$(XCODE_SDK)/usr/lib/ -isysroot $(XCODE_SDK) -mappletvos-version-min=$(TVOS_MIN_VERSION)" \
+	CFLAGS="-Oz -fno-exceptions -Wno-sign-compare $(ICU_DEFINES) -isysroot $(XCODE_SDK) -I$(XCODE_SDK)/usr/include/ -arch $(TVOS_ARCH) -mappletvos-version-min=$(TVOS_MIN_VERSION)" \
+	CXXFLAGS="-Oz -fno-exceptions -Wno-sign-compare $(ICU_DEFINES) -isysroot $(XCODE_SDK) -I$(XCODE_SDK)/usr/include/ -I./include/ -arch $(TVOS_ARCH) -mappletvos-version-min=$(TVOS_MIN_VERSION)" \
+	LDFLAGS="-L$(XCODE_SDK)/usr/lib/ -isysroot $(XCODE_SDK) -mappletvos-version-min=$(TVOS_MIN_VERSION)" \
 	CC="$(XCODE_DEVELOPER)/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang" \
 	CXX="$(XCODE_DEVELOPER)/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++"
 

--- a/eng/icu.tvossimulator.mk
+++ b/eng/icu.tvossimulator.mk
@@ -1,9 +1,9 @@
-TVOS_MIN_VERSION=10.0
+TVOS_MIN_VERSION=11.0
 
 ifeq ($(TARGET_ARCHITECTURE),x64)
 	TVOS_ARCH=x86_64
 	TVOS_SDK=appletvsimulator
-	TVOS_ICU_HOST=i686-apple-darwin
+	TVOS_ICU_HOST=x86_64-apple-darwin
 endif
 ifeq ($(TARGET_ARCHITECTURE),arm64)
 	TVOS_ARCH=arm64
@@ -15,9 +15,9 @@ XCODE_DEVELOPER := $(shell xcode-select --print-path)
 XCODE_SDK := $(shell xcodebuild -version -sdk $(TVOS_SDK) | grep -E '^Path' | sed 's/Path: //')
 
 CONFIGURE_COMPILER_FLAGS += \
-	CFLAGS="-fembed-bitcode -Oz -fno-exceptions -Wno-sign-compare $(ICU_DEFINES) -isysroot $(XCODE_SDK) -I$(XCODE_SDK)/usr/include/ -arch $(TVOS_ARCH) -mappletvsimulator-version-min=$(TVOS_MIN_VERSION)" \
-	CXXFLAGS="-fembed-bitcode -Oz -fno-exceptions -Wno-sign-compare $(ICU_DEFINES) -isysroot $(XCODE_SDK) -I$(XCODE_SDK)/usr/include/ -I./include/ -arch $(TVOS_ARCH) -mappletvsimulator-version-min=$(TVOS_MIN_VERSION)" \
-	LDFLAGS="-fembed-bitcode -L$(XCODE_SDK)/usr/lib/ -isysroot $(XCODE_SDK) -mappletvsimulator-version-min=$(TVOS_MIN_VERSION)" \
+	CFLAGS="-Oz -fno-exceptions -Wno-sign-compare $(ICU_DEFINES) -isysroot $(XCODE_SDK) -I$(XCODE_SDK)/usr/include/ -arch $(TVOS_ARCH) -mappletvsimulator-version-min=$(TVOS_MIN_VERSION)" \
+	CXXFLAGS="-Oz -fno-exceptions -Wno-sign-compare $(ICU_DEFINES) -isysroot $(XCODE_SDK) -I$(XCODE_SDK)/usr/include/ -I./include/ -arch $(TVOS_ARCH) -mappletvsimulator-version-min=$(TVOS_MIN_VERSION)" \
+	LDFLAGS="-L$(XCODE_SDK)/usr/lib/ -isysroot $(XCODE_SDK) -mappletvsimulator-version-min=$(TVOS_MIN_VERSION)" \
 	CC="$(XCODE_DEVELOPER)/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang" \
 	CXX="$(XCODE_DEVELOPER)/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++"
 

--- a/eng/nuget/Microsoft.NETCore.Runtime.ICU.Transport.pkgproj
+++ b/eng/nuget/Microsoft.NETCore.Runtime.ICU.Transport.pkgproj
@@ -144,15 +144,6 @@
     <File Condition="'$(OverrideBundledDatFiles)' == 'true'" Include="$(RepoRoot)\artifacts\bin\icu-iossimulator-x64\*.dat" TargetPath="runtimes\iossimulator-x64\native\lib\%(Filename).dat" SkipPackageFileCheck="true" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(AddAllTargetOSToPackage)' == 'true' or '$(PackageRID)' == 'iossimulator-x86'">
-    <File Include="$(RepoRoot)\artifacts\bin\icu-iossimulator-x86\lib\libicui18n.a" TargetPath="runtimes\iossimulator-x86\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
-    <File Include="$(RepoRoot)\artifacts\bin\icu-iossimulator-x86\lib\libicuuc.a" TargetPath="runtimes\iossimulator-x86\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
-    <File Include="$(RepoRoot)\artifacts\bin\icu-iossimulator-x86\lib\libicudata.a" TargetPath="runtimes\iossimulator-x86\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
-    <File Include="$(RepoRoot)\artifacts\bin\icu-iossimulator-x86\include\**" TargetPath="runtimes\iossimulator-x86\native\include\%(RecursiveDir)%(Filename)%(Extension)" SkipPackageFileCheck="true" />
-    <File Condition="'$(OverrideBundledDatFiles)' != 'true'" Include="$(RepoRoot)\eng\prebuilts\mobile\*.dat" TargetPath="runtimes\iossimulator-x86\native\lib\%(Filename).dat" SkipPackageFileCheck="true" />
-    <File Condition="'$(OverrideBundledDatFiles)' == 'true'" Include="$(RepoRoot)\artifacts\bin\icu-iossimulator-x86\*.dat" TargetPath="runtimes\iossimulator-x86\native\lib\%(Filename).dat" SkipPackageFileCheck="true" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(AddAllTargetOSToPackage)' == 'true' or '$(PackageRID)' == 'iossimulator-arm64'">
     <File Include="$(RepoRoot)\artifacts\bin\icu-iossimulator-arm64\lib\libicui18n.a" TargetPath="runtimes\iossimulator-arm64\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
     <File Include="$(RepoRoot)\artifacts\bin\icu-iossimulator-arm64\lib\libicuuc.a" TargetPath="runtimes\iossimulator-arm64\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
@@ -169,15 +160,6 @@
     <File Include="$(RepoRoot)\artifacts\bin\icu-ios-arm64\include\**" TargetPath="runtimes\ios-arm64\native\include\%(RecursiveDir)%(Filename)%(Extension)" SkipPackageFileCheck="true" />
     <File Condition="'$(OverrideBundledDatFiles)' != 'true'" Include="$(RepoRoot)\eng\prebuilts\mobile\*.dat" TargetPath="runtimes\ios-arm64\native\lib\%(Filename).dat" SkipPackageFileCheck="true" />
     <File Condition="'$(OverrideBundledDatFiles)' == 'true'" Include="$(RepoRoot)\artifacts\bin\icu-ios-arm64\*.dat" TargetPath="runtimes\ios-arm64\native\lib\%(Filename).dat" SkipPackageFileCheck="true" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(AddAllTargetOSToPackage)' == 'true' or '$(PackageRID)' == 'ios-arm'">
-    <File Include="$(RepoRoot)\artifacts\bin\icu-ios-arm\lib\libicui18n.a" TargetPath="runtimes\ios-arm\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
-    <File Include="$(RepoRoot)\artifacts\bin\icu-ios-arm\lib\libicuuc.a" TargetPath="runtimes\ios-arm\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
-    <File Include="$(RepoRoot)\artifacts\bin\icu-ios-arm\lib\libicudata.a" TargetPath="runtimes\ios-arm\native\lib\%(Filename)%(Extension)" SkipPackageFileCheck="true" />
-    <File Include="$(RepoRoot)\artifacts\bin\icu-ios-arm\include\**" TargetPath="runtimes\ios-arm\native\include\%(RecursiveDir)%(Filename)%(Extension)" SkipPackageFileCheck="true" />
-    <File Condition="'$(OverrideBundledDatFiles)' != 'true'" Include="$(RepoRoot)\eng\prebuilts\mobile\*.dat" TargetPath="runtimes\ios-arm\native\lib\%(Filename).dat" SkipPackageFileCheck="true" />
-    <File Condition="'$(OverrideBundledDatFiles)' == 'true'" Include="$(RepoRoot)\artifacts\bin\icu-ios-arm\*.dat" TargetPath="runtimes\ios-arm\native\lib\%(Filename).dat" SkipPackageFileCheck="true" />
   </ItemGroup>
 
   <!-- MacCatalyst -->


### PR DESCRIPTION
We did the same in dotnet/runtime with https://github.com/dotnet/runtime/pull/79349 and https://github.com/dotnet/runtime/pull/81965
