### PR TITLE
Only use lld linker if it is available

### DIFF
--- a/eng/icu.mk
+++ b/eng/icu.mk
@@ -43,13 +43,16 @@ include icu.$(TARGET_OS).mk
 
 UNAME_S := $(shell uname -s)
 LINKER_OVERRIDE = 
-ifeq ($(filter $(USE_DEFAULT_LINKER),false),)
 ifeq ($(UNAME_S),Linux)
 ifeq ($(TARGET_OS),browser)
-	LINKER_OVERRIDE = LDFLAGS=-fuse-ld=lld
+    # Check if lld is available
+    LLD_EXISTS := $(shell command -v lld 2> /dev/null)
+	ifneq ($(LLD_EXISTS),)
+        LINKER_OVERRIDE = LDFLAGS=-fuse-ld=lld
+    endif
 endif
 endif
-endif
+
 
 # Host build
 $(HOST_OBJDIR) $(TARGET_BINDIR) $(TARGET_OBJDIR):

--- a/eng/icu.mk
+++ b/eng/icu.mk
@@ -53,7 +53,6 @@ ifeq ($(TARGET_OS),browser)
 endif
 endif
 
-
 # Host build
 $(HOST_OBJDIR) $(TARGET_BINDIR) $(TARGET_OBJDIR):
 	mkdir -p $@

--- a/eng/icu.mk
+++ b/eng/icu.mk
@@ -64,7 +64,8 @@ $(HOST_OBJDIR)/.stamp-host: $(HOST_OBJDIR)/.stamp-configure-host
 
 $(HOST_OBJDIR)/.stamp-configure-host: | $(HOST_OBJDIR)
 	cd $(HOST_OBJDIR) && $(TOP)/icu/icu4c/source/configure \
-	--disable-icu-config --disable-extras --disable-tests --disable-samples
+	--disable-icu-config --disable-extras --disable-tests --disable-samples \
+	$(LINKER_OVERRIDE)
 	touch $@
 
 
@@ -116,4 +117,4 @@ $(eval $(call TargetBuildTemplate,icudt_no_CJK,icudt_no_CJK))
 $(eval $(call TargetBuildTemplate,icudt_EFIGS,icudt_EFIGS))
 
 # build source+data for the main "icudt" filter and only data for the other filters
-all: lib-icudt data-icudt #data-icudt_no_CJK data-icudt_EFIGS data-icudt_CJK data-icudt_hybrid
+all: lib-icudt data-icudt data-icudt_no_CJK data-icudt_EFIGS data-icudt_CJK data-icudt_hybrid

--- a/eng/icu.mk
+++ b/eng/icu.mk
@@ -43,9 +43,11 @@ include icu.$(TARGET_OS).mk
 
 UNAME_S := $(shell uname -s)
 LINKER_OVERRIDE = 
+ifeq ($(filter $(USE_DEFAULT_LINKER),false),)
 ifeq ($(UNAME_S),Linux)
 ifeq ($(TARGET_OS),browser)
 	LINKER_OVERRIDE = LDFLAGS=-fuse-ld=lld
+endif
 endif
 endif
 
@@ -59,8 +61,7 @@ $(HOST_OBJDIR)/.stamp-host: $(HOST_OBJDIR)/.stamp-configure-host
 
 $(HOST_OBJDIR)/.stamp-configure-host: | $(HOST_OBJDIR)
 	cd $(HOST_OBJDIR) && $(TOP)/icu/icu4c/source/configure \
-	--disable-icu-config --disable-extras --disable-tests --disable-samples \
-	$(LINKER_OVERRIDE)
+	--disable-icu-config --disable-extras --disable-tests --disable-samples
 	touch $@
 
 
@@ -112,4 +113,4 @@ $(eval $(call TargetBuildTemplate,icudt_no_CJK,icudt_no_CJK))
 $(eval $(call TargetBuildTemplate,icudt_EFIGS,icudt_EFIGS))
 
 # build source+data for the main "icudt" filter and only data for the other filters
-all: lib-icudt data-icudt data-icudt_no_CJK data-icudt_EFIGS data-icudt_CJK data-icudt_hybrid
+all: lib-icudt data-icudt #data-icudt_no_CJK data-icudt_EFIGS data-icudt_CJK data-icudt_hybrid

--- a/eng/icu.mk
+++ b/eng/icu.mk
@@ -45,11 +45,11 @@ UNAME_S := $(shell uname -s)
 LINKER_OVERRIDE = 
 ifeq ($(UNAME_S),Linux)
 ifeq ($(TARGET_OS),browser)
-    # Check if lld is available
-    LLD_EXISTS := $(shell command -v lld 2> /dev/null)
+	# Check if lld is available
+	LLD_EXISTS := $(shell command -v lld 2> /dev/null)
 	ifneq ($(LLD_EXISTS),)
-        LINKER_OVERRIDE = LDFLAGS=-fuse-ld=lld
-    endif
+		LINKER_OVERRIDE = LDFLAGS=-fuse-ld=lld
+	endif
 endif
 endif
 


### PR DESCRIPTION
### Use case:
E.g. issue: https://github.com/dotnet/runtime/issues/99222. Users need to be able to build ICU locally. In [docs](https://github.com/dotnet/runtime/blob/89bba37a92053f52e38d5a5c81a1f3510319dabf/docs/design/features/globalization-icu-wasm.md?plain=1#L17) we provide them info how to do it.

### Without this PR:
` ./build.sh /p:TargetOS=Browser /p:TargetArchitecture=wasm /p:IcuTracing=true` on Linux finishes with

```
Build succeeded in 0.3s
Restore complete (2.5s)
  icu failed with errors (388.7s)
    /workspaces/icu/eng/icu.proj(40,5): error MSB3073: The command "make -f icu.mk all TARGET_OS=browser TARGET_ARCHITECTURE=wasm ICU_TRACING=true WASI_SDK_PATH= ICU_TRACING=true  DOTNET_EMSCRIPTEN_LLVM_ROOT=/workspaces/icu/artifacts/obj/emsdk//bin/ DOTNET_EMSCRIPTEN_NODE_JS=/workspaces/icu/artifacts/obj/emsdk//bin/node DOTNET_EMSCRIPTEN_BINARYEN_ROOT=/workspaces/icu/artifacts/obj/emsdk// EMSDK_PATH=/workspaces/icu/artifacts/obj/emsdk/ SHELL=/bin/bash" exited with code 2. [/workspaces/icu/eng/icu.proj]

Build failed with errors in 392.1s
Build failed with exit code 1. Check errors above.
```

### With this PR:
We check if `lld` is available and we append `LDFLAGS=-fuse-ld=lld` or not (and then we rely on the default linker).