### PR TITLE
Rebrand to patch 1

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <VersionPrefix>10.0.0</VersionPrefix>
-    <PreReleaseVersionLabel>rtm</PreReleaseVersionLabel>
-    <PreReleaseVersionIteration>
-    </PreReleaseVersionIteration>
+    <VersionPrefix>10.0.1</VersionPrefix>
+    <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
+    <PreReleaseVersionIteration></PreReleaseVersionIteration>
   </PropertyGroup>
   <PropertyGroup>
     <!-- emsdk -->


### PR DESCRIPTION
Increment patch version 0 -> 1 on dotnet/release/10.0

Sets prerelease label to 'servicing' and iteration to empty string.