### PR TITLE
Revert temporary error flag for key mapping

### DIFF
--- a/icu/icu4c/source/common/uloc_keytype.cpp
+++ b/icu/icu4c/source/common/uloc_keytype.cpp
@@ -168,8 +168,9 @@ initFromResourceBundle(UErrorCode& sts) {
         }
 
         // look up type map for the key, and walk through the mapping data
-        LocalUResourceBundlePointer typeMapResByKey(ures_getByKey(typeMapRes.getAlias(), legacyKeyId, NULL, &sts));
-        if (U_FAILURE(sts)) {
+        tmpSts = U_ZERO_ERROR;
+        LocalUResourceBundlePointer typeMapResByKey(ures_getByKey(typeMapRes.getAlias(), legacyKeyId, NULL, &tmpSts));
+        if (U_FAILURE(tmpSts)) {
             // We fail here if typeMap does not have an entry corresponding to every entry in keyMap (should
             // not happen for valid keyTypeData), or if ures_getByKeyfails fails for some other reason
             // (e.g. data file cannot be loaded, using stubdata, over-aggressive data filtering has removed


### PR DESCRIPTION
For details see: https://github.com/dotnet/runtime/pull/121202#issuecomment-3497739805.

Setting `sts` to error would fail the whole mapping loading process. We don't want it because the missing keys are expected to be missing. We are reverting the code to the state from before icu 72 upgrade: https://github.com/dotnet/icu/blob/026acdf53ab3882a86f216d117803e04cfa5c70b/icu/icu4c/source/common/uloc_keytype.cpp#L171.