### PR TITLE
Add Python to the CodeQL language matrix

### DIFF
--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -27,7 +27,7 @@ extends:
   parameters:
     sdl:
       codeql:
-        language: cpp,java
+        language: cpp,java,python
       tsa:
         enabled: true
       policheck:


### PR DESCRIPTION
## Description

Extend the CodeQL language matrix in the official pipeline from `cpp,java` to `cpp,java,python`, so that the Python sources in this repository are analysed alongside the existing C++ and Java coverage.

The change affects only the official pipeline. Public pull request validation does not run CodeQL, so the checks here confirm that the build is unaffected rather than that the analysis succeeds. Verification of the Python database requires the next internal official build after merge.
