### PR TITLE
Add missing ICU CodeQL Python and GitHub coverage

### DIFF
--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -140,7 +140,7 @@ extends:
             - name: Codeql.BuildIdentifier
               value: ado_android
             - name: Codeql.Cadence
-              value: 0
+              value: 72
             - name: Codeql.Enabled
               value: true
             - name: Codeql.Language
@@ -195,7 +195,7 @@ extends:
             - name: Codeql.BuildIdentifier
               value: github_android
             - name: Codeql.Cadence
-              value: 0
+              value: 72
             - name: Codeql.Enabled
               value: true
             - name: Codeql.Language

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -26,8 +26,6 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
     sdl:
-      codeql:
-        language: cpp,java
       tsa:
         enabled: true
       policheck:
@@ -138,7 +136,32 @@ extends:
               image: $(LinuxImage)
               os: linux
             container: android
+            variables:
+            - name: Codeql.BuildIdentifier
+              value: ado_android
+            - name: Codeql.Cadence
+              value: 0
+            - name: Codeql.Enabled
+              value: true
+            - name: Codeql.Language
+              value: cpp,java,python
+            - name: Codeql.TSAEnabled
+              value: true
             steps:
+            - bash: |
+                mkdir which-shim
+                echo '#!/bin/sh' > which-shim/which
+                echo 'command -v "$@"' >> which-shim/which
+                chmod +x which-shim/which
+                echo "##vso[task.prependpath]$PWD/which-shim"
+              displayName: Add a which shim for CodeQL
+              condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/dotnet/main'))
+            - task: CodeQL3000Init@0
+              displayName: Initialize ADO CodeQL
+              condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/dotnet/main'))
+            - bash: python3 -m compileall -q eng/common/cross/install-debs.py
+              displayName: Compile Python sources
+              condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/dotnet/main'))
             - bash: |
                 echo 'public class helloworld { public static void main(String[] args) { System.out.println("Hello world"); } }' > helloworld.java
                 javac helloworld.java
@@ -150,11 +173,65 @@ extends:
                 ./build.sh --ci --restore --build --configuration $(_BuildConfig) /p:TargetOS=Android /p:TargetArchitecture=arm64 $(_InternalBuildArgs)
                 ./build.sh --ci --restore --build --configuration $(_BuildConfig) /p:TargetOS=Android /p:TargetArchitecture=arm $(_InternalBuildArgs)
               displayName: Build
+            - task: CodeQL3000Finalize@0
+              displayName: Finalize ADO CodeQL
+              condition: and(succeededOrFailed(), eq(variables['Build.SourceBranch'], 'refs/heads/dotnet/main'))
             templateContext:
               outputs:
               - output: pipelineArtifact
                 targetPath: $(System.DefaultWorkingDirectory)/artifacts/bin
                 artifactName: Artifacts_Android
+
+          - job: CodeQL_GitHub
+            displayName: CodeQL GitHub
+            condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/dotnet/main'))
+            timeoutInMinutes: 360
+            pool:
+              name: $(DncEngInternalBuildPool)
+              image: $(LinuxImage)
+              os: linux
+            container: android
+            variables:
+            - name: Codeql.BuildIdentifier
+              value: github_android
+            - name: Codeql.Cadence
+              value: 0
+            - name: Codeql.Enabled
+              value: true
+            - name: Codeql.Language
+              value: cpp,java,python
+            - name: Codeql.ADO.Build.Repository.Provider
+              value: override
+            - name: Codeql.ADO.Build.Repository.Uri
+              value: https://github.com/dotnet/icu
+            - name: skipComponentGovernanceDetection
+              value: true
+            steps:
+            - bash: |
+                mkdir which-shim
+                echo '#!/bin/sh' > which-shim/which
+                echo 'command -v "$@"' >> which-shim/which
+                chmod +x which-shim/which
+                echo "##vso[task.prependpath]$PWD/which-shim"
+              displayName: Add a which shim for CodeQL
+            - task: CodeQL3000Init@0
+              displayName: Initialize GitHub CodeQL
+            - bash: python3 -m compileall -q eng/common/cross/install-debs.py
+              displayName: Compile Python sources
+            - bash: |
+                echo 'public class helloworld { public static void main(String[] args) { System.out.println("Hello world"); } }' > helloworld.java
+                javac helloworld.java
+                java helloworld
+              displayName: Run java helloworld
+            - bash: |
+                ./build.sh --ci --restore --build --configuration $(_BuildConfig) /p:TargetOS=Android /p:TargetArchitecture=x64 $(_InternalBuildArgs)
+                ./build.sh --ci --restore --build --configuration $(_BuildConfig) /p:TargetOS=Android /p:TargetArchitecture=x86 $(_InternalBuildArgs)
+                ./build.sh --ci --restore --build --configuration $(_BuildConfig) /p:TargetOS=Android /p:TargetArchitecture=arm64 $(_InternalBuildArgs)
+                ./build.sh --ci --restore --build --configuration $(_BuildConfig) /p:TargetOS=Android /p:TargetArchitecture=arm $(_InternalBuildArgs)
+              displayName: Build
+            - task: CodeQL3000Finalize@0
+              displayName: Finalize GitHub CodeQL
+              condition: succeededOrFailed()
 
           ############ PACK AND PUBLISH ############
           - job: Publish_Packages


### PR DESCRIPTION
This change only addresses identities that are actually missing coverage.

Current evidence
- ADO `dnceng/internal/dotnet-icu|cpp` and `dnceng/internal/dotnet-icu|java` already have current Android-traced databases from `2026-08-07 11:27:57`. Build `3041886` reports those databases as `Finished` at https://codeql.microsoft.com/job/8115d4ce-a4fc-4462-9571-8507c0e4894a and https://codeql.microsoft.com/job/1a00c205-eb6d-4767-911f-8ceccb885c7d. The same build then skips new databases because the normal 72 hour cadence window is still open, which is expected and does not indicate stale coverage. If S360 keeps either ADO identity active after refresh, that is a CAP/S360 ingestion mismatch rather than a missing scan.
- ADO `dnceng/internal/dotnet-icu|python` is missing. The Android build log identifies Python artifacts, but the current pipeline only enables `cpp,java`, so no Python database is created.
- GitHub `dotnet/icu|cpp`, `dotnet/icu|java`, and `dotnet/icu|python` are missing. `gh api repos/dotnet/icu/code-scanning/analyses` returns `404 no analysis found`, the repo only has `.github/workflows/backport.yml`, and the internal build logs report `Provider: TfsGit`, so the existing databases are ADO-attributed only.

What this PR changes
- Keeps CodeQL on the Android-traced build lane, which is the lane already producing the current ADO `cpp` and `java` databases.
- Adds the missing ADO `python` language on that same lane while preserving `cpp` and `java` coverage.
- Adds a separate GitHub-attributed CodeQL lane for `dotnet/icu` using the repository override variables so the GitHub identities can be created without collapsing attribution into the ADO mirror.
- Uses the standard `Codeql.Cadence: 72` on both manual jobs to avoid duplicate scans.

Validation
- `ruby -e 'require "yaml"; YAML.load_file("eng/azure-pipelines.yml"); puts "YAML OK"'`
