### PR TITLE
Report GitHub identity for ICU CodeQL uploads

### DIFF
--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -5,6 +5,13 @@ variables:
     value: build.azurelinux.3.amd64
   - name: WindowsImage
     value: 1es-windows-2022
+  - ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(variables['Build.Repository.Name'], 'dotnet-icu')) }}:
+    - name: Codeql.ADO.Build.Repository.Provider
+      value: GitHub
+    - name: Codeql.ADO.Build.Repository.Uri
+      value: https://github.com/dotnet/icu
+    - name: Codeql.ADO.Build.SourceBranchName
+      value: $[replace(variables['Build.SourceBranch'], 'refs/heads/', '')]
 
 trigger:
   batch: true


### PR DESCRIPTION
## Description

Report CodeQL uploads under the GitHub repository instead of the internal ADO mirror.
